### PR TITLE
Fix AttributeError: Replace refbcf with refvcf in argument check

### DIFF
--- a/prsedm/extensions/score_dm.py
+++ b/prsedm/extensions/score_dm.py
@@ -165,7 +165,7 @@ def main():
     args = parser.parse_args()
     logging.info("Parsed command line arguments.")
 
-    if args.impute and not args.refbcf:
+    if args.impute and not args.refvcf:
         parser.error("--ref-dir is required if imputation is enabled.")
 
     try:


### PR DESCRIPTION
This pull request fixes a bug in the prsedm tool where an AttributeError is raised when the --impute flag is used. The problem occurs because the argument **refbcf** is referenced in the code, but it should be **refvcf**, matching the argument defined in the CLI.

Issue:
When running the following command:
```
prsedm --vcf Maryland_rs.vcf.gz --scores "t1dgrs2-sharp24" --build hg38 --impute --refvcf "*/ReferenceData/TOPMED/"
```
The following error is produced:
```
Traceback (most recent call last):  
  File "*/envs/prsedm/bin/prsedm", line 10, in <module>  
    sys.exit(main())  
  File "*/envs/prsedm/lib/python3.12/site-packages/prsedm/extensions/score_dm.py", line 168, in main  
    if args.impute and not args.refbcf:  
                           ^^^^^^^^^^^  
AttributeError: 'Namespace' object has no attribute 'refbcf'. Did you mean: 'refvcf'?  
```
The error happens because the line:
```
if args.impute and not args.refbcf:  
```
references **refbcf**, which is not a valid attribute of args. **According to the --help output, the correct attribute name is _refvcf_**.
Fix:
To resolve the error, the line:
```
if args.impute and not args.refbcf:  
```
is updated to:

```
if args.impute and not args.refvcf:  

```