### PR TITLE
Add logging.FileHandler only if directory is writeable

### DIFF
--- a/prsedm/core/utilities.py
+++ b/prsedm/core/utilities.py
@@ -29,7 +29,7 @@ class PRSConfig:
 
 
 def configure_logging():
-    log_file = "f{__name__}.log"
+    log_file = f"{__name__}.log"
     """Configure logging with both file and stream handlers."""
     log_path = os.path.join(os.path.dirname(__file__), "..", log_file)
     logging.basicConfig(

--- a/prsedm/core/utilities.py
+++ b/prsedm/core/utilities.py
@@ -32,10 +32,16 @@ def configure_logging():
     log_file = f"{__name__}.log"
     """Configure logging with both file and stream handlers."""
     log_path = os.path.join(os.path.dirname(__file__), "..", log_file)
+
+    if os.access(os.path.dirname(log_path), os.W_OK):
+        log_handlers = [logging.FileHandler(log_path), logging.StreamHandler()]
+    else:
+        log_handlers = [logging.StreamHandler()]
+
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-        handlers=[logging.FileHandler(log_path), logging.StreamHandler()]
+        handlers=log_handlers
     )
 
 


### PR DESCRIPTION
When installing PRSedm as a root-owned package or in a container, writing to the log file may not be possible by a non-superuser.
    
We add a check to see if the path is writeable before adding logging.FileHandler(log_path) to the list of log handlers.
    
If not writeable, the logging.StreamHandler() will simply log to stderr.

---

Also included one-line fix for f-string syntax when creating log_path.